### PR TITLE
OAuth doc tweaks

### DIFF
--- a/0004-oauth/README.md
+++ b/0004-oauth/README.md
@@ -172,7 +172,7 @@ Instead of relying on dynamic client registration, clients will be automatically
 In addition to be conformant with the Client Metadata described in [RFC7591][], the following rules also apply to the client metadata document. These rules **must** be enforced by the AS.
 
 - the metadata **must** contain `client_id`, and this value **must** be strictly equal to the client id that was used to resolve this document.
-- the metadata **must** contain `"dpop_bound_access_tokens": true`. All clients must use DPoP ([RFC9449][]) proof when requesting tokens.
+- the metadata **must** contain `"dpop_bound_access_tokens": true`. All clients must use [DPoP][RFC9449]) proof when requesting tokens.
 - the metadata **must** contain at least one `redirect_uris` entry.
 - the `application_type`, if present, **must** either be `"web"` or `"native"` (default is `web`).
 - `"web"` clients must use HTTPS for all their `redirect_uris`.
@@ -187,7 +187,7 @@ In addition to be conformant with the Client Metadata described in [RFC7591][], 
 - the `response_types` metadata **must** contain `code`. Other response types can be added (e.g. `id_token`) but won't necessarily be supported by the AS.
 - the `scope` metadata **must** contain `offline_access` if, and only if, `refresh_token` is present in `grant_types`.
 - the `scope` metadata can be used to restrict which scopes are allowed during the authorization flow for that client. No scope are allowed by default.
-- the `response_types` _may_ contain `"token"`. However, since PKCE ([RFC7636][]) is mandatory for all exchanges, AS **must** only allow `"token"` response type to be used when PKCE is irrelevant (such as during the `password` grant type).
+- the `response_types` _may_ contain `"token"`. However, since [PKCE][RFC7636]) is mandatory for all exchanges, AS **must** only allow `"token"` response type to be used when PKCE is irrelevant (such as during the `password` grant type).
 - every `token_endpoint_auth_method` (where `<endpoint>` is `token`, `revocation`, `introspection`), if present, **must** be set to `private_key_jwt` or `none`.
 - if any of the `token_endpoint_auth_method` is set to `private_key_jwt`, the client **must** provide a JSON web key set (JWKS), either through the `jwks` metadata or through the `jwks_uri` metadata, that contains at least one key.
 - `jwks` and `jwks_uri` **must not** be used together.
@@ -268,7 +268,7 @@ In addition to the [OAuth 2.0 Security Best Current Practice][DRAFT-OAUTH-SECURI
 - Response modes: `fragment`, `query`, `form_post`
 - The Token & PAR Endpoints **must** support the `none` & `private_key_jwt` Authentication Methods.
 - They **must** require PKCE for all authentication requests.
-- The `code_challenge_methods_supported` server metadata (PKCE [RFC7636][]) **must** contain `RS256`. The AS _should not_ allow the `plain` challenge method to be used.
+- The `code_challenge_methods_supported` server metadata ([PKCE][RFC7636]) **must** contain `RS256`. The AS _should not_ allow the `plain` challenge method to be used.
 - They **must** require DPoP for all tokens requests. They **must** support DPoP for authorization requests.
 - Access tokens **must** have a maximum lifetime of 1 hour.
 - The OAuth authorization server metadata must be expose through the `oauth-authorization-server` well-known endpoint (see the [server metadata](#server-metadata) section)
@@ -394,7 +394,7 @@ In this architecture, the authorization flow works as follows:
 - Upon successful authorization, the authorization server redirects the user back to the backend's `<redirect_uri>` with an authorization `code` in the URL.
 - The backend stores that `code` in the user's session.
 - The frontend app is loaded in the browser.
-- The app creates a **non exportable** asymmetric key pair ([WEBCRYPTO]). The private key should be stored in the browser's indexedDB. This keypair will be used for generating DPoP proofs.
+- The app creates a **non exportable** asymmetric key pair ([WebCrypto][WEBCRYPTO]). The private key should be stored in the browser's indexedDB. This keypair will be used for generating DPoP proofs.
 - The frontend app asks the backend for an access token by providing a `dpop` proof, along with its session id.
 - The backend uses the `code` (loaded from the session data), along with a `client_assertion` (JWT) and the frontend app's `dpop` proof, to request an access token from the `<token_endpoint>` (retrieved from the Authorization Server Metadata).
 - The backend stores the access token & refresh token in its secure storage, linked to the user's session.
@@ -439,7 +439,7 @@ In this architecture, the authorization flow works as follows:
 - The AS loads & validates the client metadata (C)
 - The app redirects the user to the `<authorization_endpoint>` (retrieved from the Authorization Server Metadata), either in the same tab or in a popup/new tab.
 - Upon successful authorization, the authorization server redirects the user back to the app's `<redirect_uri>` with an authorization `code` in the URL.
-- The app creates a **non exportable** asymmetric key pair ([WEBCRYPTO]). The private key should be stored in the browser's indexedDB so it can be re-used after a reload of the browser. This keypair will be used for generating DPoP proofs.
+- The app creates a **non exportable** asymmetric key pair ([WebCrypto][WEBCRYPTO]). The private key should be stored in the browser's indexedDB so it can be re-used after a reload of the browser. This keypair will be used for generating DPoP proofs.
 - The app uses the `code`, along with a `dpop` proof, to request an access token from the `<token_endpoint>` (retrieved from the Authorization Server Metadata).
 - The app stores the tokens in the browser's storage (typically, indexedDB).
 - The app resolved the PDS url by using `aud` obtained by querying the `<introspection_endpoint>` (retrieved from the Authorization Server Metadata).
@@ -492,7 +492,7 @@ The AS will then authenticate the user and ask them to approve the request. Sile
 
 Upon successful authorization by the user, the AS will issue an authorization code and redirect the user back to the client's `redirect_uri`.
 
-The client will use that code (along with [PKCE][RFC7636], DPoP ([RFC9449]) & JWT for Assertion Framework protocol ([RFC7523]) tokens), to contact the `/token` endpoint on the AS. The AS will make all necessary checks (JWT, PKCE, DPoP key <> client assertion key, request expiration, etc.) to ensure that the request is valid. This will be enforced by the AS. Here is an example of such a request:
+The client will use that code (along with [PKCE][RFC7636], [DPoP][RFC9449] & [JWT for Assertion Framework protocol][RFC7523]) tokens), to contact the `/token` endpoint on the AS. The AS will make all necessary checks (JWT, PKCE, DPoP key <> client assertion key, request expiration, etc.) to ensure that the request is valid. This will be enforced by the AS. Here is an example of such a request:
 
 ```http
 POST https://entryway.example.com/oauth/token
@@ -523,7 +523,7 @@ Cache-Control: no-store
 
 The AS will bind those tokens to the `client_id` and the public key used to authenticate the client. The validity of the access token will be limited to a short period of time (e.g. 1 hour). The validity of the refresh token **must** be limited to a short period of time (e.g. 24 hours) or expire if they are not used in some amount of time (e.g. 24 hours). The AS **can** use longer periods for authenticated clients but **must not** allow refresh tokens without a limited lifetime.
 
-Refresh tokens will later be used in order to obtain new access tokens. These requests on the `token_endpoint` must be authenticated using the same method (JWT for Assertion Framework protocol ([RFC7523])). the same DPoP key must be presented in the `DPoP` header of the request.
+Refresh tokens will later be used in order to obtain new access tokens. These requests on the `token_endpoint` must be authenticated using the same method ([JWT for Assertion Framework protocol][RFC7523]). The same DPoP key must be presented in the `DPoP` header of the request.
 
 ### Authorization flow from a serverless browser app
 
@@ -571,7 +571,7 @@ https://bar.xzy/oauth2/authorize
 The browser will open that URL and the user will be redirected to the AS. The AS will flag this authorization request as "non-confidential". This will cause the following limitations to be applied:
 
 - No silent sign-on will be allowed in this case (any `prompt=none` request will result in `error=login_required` errors)
-- The user will be shown a confirmation [AUTH-UI] whether he already approved this client or not.
+- The user will be shown a confirmation [Authorization Interface][AUTH-UI] whether he already approved this client or not.
 - The total lifetime of the tokens will be limited.
 - The DPoP key must be a key never encountered before. This is done to prevent a malicious actor who managed to steal a DPoP key from a client to be able to use it during future sessions, at which point any vulnerability might have been fixed.
 
@@ -620,7 +620,7 @@ If, at any point, a public key that was used by a client to authenticate itself 
 
 ### Impersonation
 
-Since client names and logo can easily be spoofed, they will **not** be used in the [AUTH-UI] to avoid any misdirection while the user make their choice. The best (an only) way users nowadays know how to identify an internet actor is by its domain name. Their handle could also be used, but these are not as easy to identify as being authentic as domain names are.
+Since client names and logo can easily be spoofed, they will **not** be used in the [Authorization Interface][AUTH-UI] to avoid any misdirection while the user make their choice. The best (an only) way users nowadays know how to identify an internet actor is by its domain name. Their handle could also be used, but these are not as easy to identify as being authentic as domain names are.
 
 ### Server Side Request Forgery (SSRF)
 
@@ -644,7 +644,7 @@ Yes. There is nothing in this spec that prevents the Authorization Server to be 
 
 ### `application_type` is part of OIDC, why is it part of this spec ?
 
-The `application_type` client metadata claim is part of [OIDC-CLIENT-REGISTRATION] and not part of [Dynamic Client Registration Protocol][RFC7591]. While this spec does not require OIDC compatibility, that particular claim was added for the following reasons:
+The `application_type` client metadata claim is part of [OIDC Client Registration][OIDC-CLIENT-REGISTRATION] and not part of [Dynamic Client Registration Protocol][RFC7591]. While this spec does not require OIDC compatibility, that particular claim was added for the following reasons:
 
 - [draft-oauth-security-topics][DRAFT-OAUTH-SECURITY-TOPICS] distinguishes security practices for native & web apps.
 - [draft-oauth-browser-based-apps][DRAFT-OAUTH-BROWSER-BASED-APPS] requires exact matching of the `redirect_uri` for web apps. This rules out the use of loopback redirect uris for web apps.
@@ -661,35 +661,35 @@ While technically possible it's not recommended at the current time. Clients att
 - [OAuth Support in Bluesky and AT Protocol](https://aaronparecki.com/2023/03/09/5/bluesky-and-oauth)
 - [IETF Working group: Web Authorization Protocol](https://datatracker.ietf.org/wg/oauth/documents/)
 - [Description of a Project](https://github.com/ewilderj/doap/wiki)
-- [INDIE-AUTH] IndieAuth
+- [IndieAuth][INDIE-AUTH]
 - [JSON for Linking Data](https://json-ld.org/)
 - [The Open Graph protocol](https://ogp.me/)
-- [DID] Decentralized Identifiers (DIDs) v1.0
-- [DID-WEB] `did:web` Method Specification
-- [DID-PLC] `did:plc` Method Specification
-- [OIDC-CORE] OpenID Connect Core 1.0
-- [OIDC-CLIENT-REGISTRATION] OpenID Connect Dynamic Client Registration 1.0
-- [RFC6749] OAuth 2.0 Authorization Framework
-- [RFC7517] JSON Web Key (JWK)
-- [RFC7519] JSON Web Token (JWT)
-- [RFC7521] Assertion Framework
-- [RFC7523] JWT for Assertion Framework
-- [RFC7591] Dynamic Client Registration Protocol
-- [RFC7592] Dynamic Client Registration Management Protocol
-- [RFC7636] Proof Key for Code Exchange (PKCE)
-- [RFC8414] Authorization Server Metadata (`/.well-known/oauth-authorization-server`)
-- [RFC9101] JWT-Secured Authorization Request (JAR)
-- [RFC9126] Pushed Authorization Requests (PAR)
-- [RFC9207] OAuth 2.0 Authorization Server Issuer Identification
-- [RFC9449] Demonstrating Proof of Possession (DPoP)
-- [DRAFT-AUTHORIZATION-SERVER-DISCOVERY] Draft: Authorization Server Discovery
-- [DRAFT-OAUTH-ATTESTATION-BASED-CLIENT-AUTH] Draft: Attestation-Based Client Authentication
-- [DRAFT-OAUTH-BROWSER-BASED-APPS] Draft: Oauth browser based apps
-- [DRAFT-OAUTH-FIRST-PARTY-APPS] Draft: OAuth 2.0 for First-Party Applications
-- [DRAFT-OAUTH-SECURITY-TOPICS] Draft: Security Best Current Practice
-- [DRAFT-OAUTH-V2-1] Draft: OAuth 2.1
-- [W3C-WEBMANIFEST] Draft: Web Application Manifest
-- [WEBCRYPTO] Web Crypto API
+- [DID][]: Decentralized Identifiers (DIDs) v1.0
+- [DID Web][DID-WEB]: `did:web` Method Specification
+- [DID PLC][DID-PLC]: `did:plc` Method Specification
+- [OIDC Core:][OIDC-CORE] OpenID Connect Core 1.0
+- [OIDC Client Registration][OIDC-CLIENT-REGISTRATION]: OpenID Connect Dynamic Client Registration 1.0
+- [RFC6749][]: OAuth 2.0 Authorization Framework
+- [RFC7517][]: JSON Web Key (JWK)
+- [RFC7519][]: JSON Web Token (JWT)
+- [RFC7521][]: Assertion Framework
+- [RFC7523][]: JWT for Assertion Framework
+- [RFC7591][]: Dynamic Client Registration Protocol
+- [RFC7592][]: Dynamic Client Registration Management Protocol
+- [RFC7636][]: Proof Key for Code Exchange (PKCE)
+- [RFC8414][]: Authorization Server Metadata (`/.well-known/oauth-authorization-server`)
+- [RFC9101][]: JWT-Secured Authorization Request (JAR)
+- [RFC9126][]: Pushed Authorization Requests (PAR)
+- [RFC9207][]: OAuth 2.0 Authorization Server Issuer Identification
+- [RFC9449][]: Demonstrating Proof of Possession (DPoP)
+- [draft-authorization-server-discovery][DRAFT-AUTHORIZATION-SERVER-DISCOVERY]: Authorization Server Discovery (Draft)
+- [draft-oauth-attestation-based-client-auth][DRAFT-OAUTH-ATTESTATION-BASED-CLIENT-AUTH]: Attestation-Based Client Authentication (Draft)
+- [draft-oauth-browser-based-apps][DRAFT-OAUTH-BROWSER-BASED-APPS]: Oauth browser based apps (Draft)
+- [draft-oauth-first-party-apps][DRAFT-OAUTH-FIRST-PARTY-APPS]: OAuth 2.0 for First-Party Applications (Draft)
+- [draft-oauth-security-topics][DRAFT-OAUTH-SECURITY-TOPICS]: Security Best Current Practice (Draft)
+- [draft-oauth-v2-1][DRAFT-OAUTH-V2-1]: OAuth 2.1 (Draft)
+- [WebManifest][W3C-WEBMANIFEST]: Web Application Manifest (Draft)
+- [WebCrypto][WEBCRYPTO]: Web Crypto API (W3C)
 
 [ATPROTO]: https://atproto.com/ 'AT Protocol'
 [AUTH-UI]: https://www.oauth.com/oauth2-servers/authorization/the-authorization-interface/ 'The Authorization Interface'

--- a/0004-oauth/README.md
+++ b/0004-oauth/README.md
@@ -656,14 +656,9 @@ While technically possible it's not recommended at the current time. Clients att
 
 ## References
 
-- [OAuth research](https://blueskyweb.notion.site/oauth2-research-762c333111ec4713b6727d3f1603d61c)
-- [OAuth resources](https://blueskyweb.notion.site/OAuth-resources-87e8cd12da4f4c07896a7887a8e0b70c)
-- [OAuth Support in Bluesky and AT Protocol](https://aaronparecki.com/2023/03/09/5/bluesky-and-oauth)
+- [OAuth Support in Bluesky and AT Protocol](https://aaronparecki.com/2023/03/09/5/bluesky-and-oauth): March 2023 blog post by Aaron Parecki
 - [IETF Working group: Web Authorization Protocol](https://datatracker.ietf.org/wg/oauth/documents/)
-- [Description of a Project](https://github.com/ewilderj/doap/wiki)
 - [IndieAuth][INDIE-AUTH]
-- [JSON for Linking Data](https://json-ld.org/)
-- [The Open Graph protocol](https://ogp.me/)
 - [DID][]: Decentralized Identifiers (DIDs) v1.0
 - [DID Web][DID-WEB]: `did:web` Method Specification
 - [DID PLC][DID-PLC]: `did:plc` Method Specification

--- a/0004-oauth/README.md
+++ b/0004-oauth/README.md
@@ -42,7 +42,7 @@ The goals we try to achieve through this framework are:
 
 ## Framework
 
-In addition to the identity resolution mechanisms specified by [[ATPROTO]], the current framework builds on top of the following specifications and drafts:
+In addition to the identity resolution mechanisms specified by [ATPROTO], the current framework builds on top of the following specifications and drafts:
 
 - [OAuth 2.0 Protected Resource Metadata draft][DRAFT-OAUTH-RESOURCE-METADATA]
 - [OAuth Client ID Metadata Document draft][DRAFT-OAUTH-CLIENT-ID-METADATA-DOCUMENT]
@@ -55,7 +55,7 @@ In addition to the identity resolution mechanisms specified by [[ATPROTO]], the 
 - [JWT for Assertion Framework protocol][RFC7523] (For authenticating clients)
 - [Pushed Authorization Requests][RFC9126]
 
-When a client needs to obtain credentials to interact with a user's PDS, it must initiate an authorization flow with the PDS's Authorization Server (AS). In order to determine the AS's authorization metadata, the client must first resolve the PDS's URI from the user's handle (see [ATPROTO]). Once the PDS URI is known (e.g. `https://shimeji.us-east.host.bsky.network`), the [protected resource metadata][DRAFT-OAUTH-RESOURCE-METADATA] document will allow the client to obtain the Authorization Server Issuer from the `authorization_servers` field. The [Authorization Server Metadata][RFC8414] endpoint (`<PDS_ORIGIN>/.well-known/oauth-authorization-server`) will allow the client to obtain all the information it needs to initiate an OAuth2 authorization flow (see the [server metadata](#server-metadata) section below).
+When a client needs to obtain credentials to interact with a user's PDS, it must initiate an authorization flow with the PDS's Authorization Server (AS). In order to determine the AS's authorization metadata, the client must first resolve the PDS's URI from the user's handle (see [ATPROTO]). Once the PDS URI is known (e.g. `https://pds.example.com`), the [protected resource metadata][DRAFT-OAUTH-RESOURCE-METADATA] document will allow the client to obtain the Authorization Server Issuer from the `authorization_servers` field. The [Authorization Server Metadata][RFC8414] endpoint (`<PDS_ORIGIN>/.well-known/oauth-authorization-server`) will allow the client to obtain all the information it needs to initiate an OAuth2 authorization flow (see the [server metadata](#server-metadata) section below).
 
 Clients do not need to be pre-registered with the Authorization Server. Instead, the Authorization Server will dynamically load the [client metadata document][DRAFT-OAUTH-CLIENT-ID-METADATA-DOCUMENT] from the `client_id`, during an authorization request, as described in the [client metadata](#client-metadata) section. The client metadata is a JSON file that contains the client's metadata (name, logo, allowed redirect URIs, expected scopes, JWKS, etc.). The content of that document is based on the [OAuth 2.0 Dynamic Client Registration Protocol][RFC7591] and [OAuth 2.0 Dynamic Client Registration Management Protocol][RFC7592] specifications.
 
@@ -131,7 +131,7 @@ The general framework is described in figure 1.
 
 Figure 1.: Authorization flow for a client. Note that neither the client nor the authorization server necessarily know about each other before the authorization flow is initiated.
 
-First step (1) is for the client to ask the user for their [ATPROTO] `@handle`, or, should they have forgotten their handle, their PDS or Entryway's URL (e.g. `bsky.social`). The client will then fetch (3) and validate (4) the Authorization Server Metadata using the method described [below](#server-metadata).
+First step (1) is for the client to ask the user for their [ATPROTO] handle, or, should they have forgotten their handle, their PDS or Entryway's URL (e.g. `pds.example.com`). The client will then fetch (3) and validate (4) the Authorization Server Metadata using the method described [below](#server-metadata).
 
 The client will then build (5) the authorization URL using [PAR][RFC9126] & [PKCE][RFC7636]. This will cause the Authorization Server to load and validate the client metadata (6) using the method described [below](#client-metadata). Once the authorization request is successfully created, the end user will be redirected to the authorize endpoint (7, 8).
 
@@ -149,7 +149,7 @@ In addition to the requested tokens, the token response must also contain, in th
 
 In addition to being bound to the client's DPoP key, all tokens issued by the AS will also be bound to the public key used by the client to authenticate itself through the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant (only for public client). If, at any point, a client stops advertising a public key that is used in active sessions, all those sessions will be invalidated. The AS will choose, at its discretion how it will implement this (proactively, whenever metadata are fetched, on the next token refresh, etc.).
 
-Because frontend only apps are not able to provide a similar mechanism to invalidate credentials at scale, [DRAFT-OAUTH-BROWSER-BASED-APPS] requires that refresh tokens "MUST set a maximum lifetime [...] or expire if they are not used in some amount of time". As an additional restriction, unauthenticated clients are not allowed use silent sign on. This means that the user will have to give its consent again (but _not_ necessarily re-authenticate itself if he still has an active session on the AS) to the client every time a period of inactivity is reached. In practice, after some inactivity period, the user will be redirected to the authorization server to re-authorize the client with a message saying: "You have been inactive for 48 hours on `bsky.app`. You are still authenticated as John Doe. To continue, please re-authorize the `bsky.app` to access your account by clicking this button".
+Because frontend only apps are not able to provide a similar mechanism to invalidate credentials at scale, [DRAFT-OAUTH-BROWSER-BASED-APPS] requires that refresh tokens "MUST set a maximum lifetime [...] or expire if they are not used in some amount of time". As an additional restriction, unauthenticated clients are not allowed use silent sign on. This means that the user will have to give its consent again (but _not_ necessarily re-authenticate itself if he still has an active session on the AS) to the client every time a period of inactivity is reached. In practice, after some inactivity period, the user will be redirected to the authorization server to re-authorize the client with a message saying: "You have been inactive for 48 hours on `app.example.com`. You are still authenticated as John Doe. To continue, please re-authorize the `app.example.com` to access your account by clicking this button".
 
 Authenticated clients **should** rotate their keys on a regular basis (e.g. on every new app release, or every month, whichever comes first). They can do so by adding a new key to their JWKS and removing the old ones from time to time. If a breach is detected, the client **must** immediately remove the compromised key from its JWKS. If the mitigation of the breach takes long, all the keys **must** be removed from the JWKS as the issue is being fixed, preventing any new tokens from being issued.
 
@@ -198,7 +198,7 @@ In addition to be conformant with the Client Metadata described in [RFC7591], th
 
 When a client ID uses "`http://localhost`" as origin, the AS will not be able to resolve the client metadata using the method described above. Instead, the Authorization Server will derive the client metadata document from the client ID.
 
-Given a Client ID with the following format: `^http://localhost(?<pathname>\/[^?]*)(<searchParams>?[^#]*)?$`, the following metadata document will be used (authoritative code bellow):
+Given a Client ID with the following format: `^http://localhost(?<pathname>\/[^?]*)(<searchParams>?[^#]*)?$`, the following metadata document will be used (authoritative code below):
 
 ```js
 const { protocol, origin, pathname, searchParams } = new URL(clientId)
@@ -296,7 +296,7 @@ The following rules must be enforced by the AS when receiving a token request.
 - Public clients **must** generate a new keypair for each set of tokens they request. Authorization servers **should** reject initial tokens requests from public clients that use the same keypair as a previous request.
 - Ensure that the client authentication method is the same as the one used during PAR (if `client_assertion` was used during PAR, the same authentication method **must** be used, with a JWT containing a distinct `jti` claim, but signed by the same key)
 - DPoP proof and client assertion **must** be signed using a different keypair.
-- The Token Response from the AS **must** contain a `sub` claim, which must be the end-user's ATPROTO identifier (`did:plc:123`)
+- The Token Response from the AS **must** contain a `sub` claim, which must be the end-user's [ATPROTO] DID (`did:plc:123`)
 
 ## Supported architectures
 
@@ -454,15 +454,15 @@ The client starts by resolving Authorization Server Metadata as described [befor
 In order to build the authorization URL, the client performs a [PAR][RFC9126] + [PKCE][RFC7636] request towards the AS, using the `pushed_authorization_request_endpoint` obtained from the PDS's [Authorization Server Metadata][RFC8414]. Here is an example of such a request:
 
 ```http
-POST https://bsky.social/oauth/par
+POST https://entryway.example.com/oauth/par
 Content-Type: application/x-www-form-urlencoded
 
 response_type=code
 &code_challenge=K2-ltc83acc4h0c9w6ESC_rEMTJ3bww-uCHaoeK1t8U
 &code_challenge_method=S256
-&client_id=bsky.app
+&client_id=app.example.com
 &state=duk681S8n00GsJpe7n9boxdzen
-&redirect_uri=https://bsky.app/my-app/oauth-callback
+&redirect_uri=https://app.example.com/my-app/oauth-callback
 &scope=scope_a scope_b scope_c
 &login_hint=did:plc:123
 &client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
@@ -485,7 +485,7 @@ Content-Type: application/json
 The client will then redirect the user to the authorize endpoint using the `request_uri` obtained from the previous step. The AS will verify that the `request_uri` is still valid. Here is what the authorization URL will look like:
 
 ```url
-https://bsky.social/oauth/authorize?client_id=bsky.app&request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3Abwc4JK-ESC0w8acc191e-Y1LTC2
+https://entryway.example.com/oauth/authorize?client_id=app.example.com&request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3Abwc4JK-ESC0w8acc191e-Y1LTC2
 ```
 
 The AS will then authenticate the user and ask them to approve the request. Silent sign-on will only be used if the user already has a session on the AS with the same DID as the one defined in the `login_hint` parameter of the PAR request.
@@ -495,15 +495,15 @@ Upon successful authorization by the user, the AS will issue an authorization co
 The client will use that code (along with [PKCE][RFC7636], DPoP ([RFC9449]) & JWT for Assertion Framework protocol ([RFC7523]) tokens), to contact the `/token` endpoint on the AS. The AS will make all necessary checks (JWT, PKCE, DPoP key <> client assertion key, request expiration, etc.) to ensure that the request is valid. This will be enforced by the AS. Here is an example of such a request:
 
 ```http
-POST https://bsky.social/oauth/token
+POST https://entryway.example.com/oauth/token
 Content-Type: application/x-www-form-urlencoded
 DPoP: <DPOP_PROOF_JWT>
 
 grant_type=authorization_code
 &code=<AUTHORIZATION_CODE>
 &code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
-&client_id=bsky.app
-&redirect_uri=https://bsky.app/my-app/oauth-callback
+&client_id=app.example.com
+&redirect_uri=https://app.example.com/my-app/oauth-callback
 &client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
 &client_assertion=<SELF_SIGNED_JWT>
 ```
@@ -534,15 +534,15 @@ The client starts by resolving Authorization Server Metadata as described [befor
 In order to build the authorization URL, the client performs a [PAR][RFC9126] + [PKCE][RFC7636] request towards the AS, using the `pushed_authorization_request_endpoint` obtained from the PDS's [Authorization Server Metadata][RFC8414]. Note that browser apps not being able to securely store a shared private key, they will not be able to use the `client_assertion` parameter. Here is an example of such a request:
 
 ```http
-POST https://bsky.social/oauth/par
+POST https://entryway.example.com/oauth/par
 Content-Type: application/x-www-form-urlencoded
 
 response_type=code
 &code_challenge=K2-ltc83acc4h0c9w6ESC_rEMTJ3bww-uCHaoeK1t8U
 &code_challenge_method=S256
-&client_id=bsky.app
+&client_id=app.example.com
 &state=duk681S8n00GsJpe7n9boxdzen
-&redirect_uri=https://bsky.app/my-app/oauth-callback
+&redirect_uri=https://app.example.com/my-app/oauth-callback
 &scope=scope_a scope_b scope_c
 &login_hint=did:plc:123
 ```
@@ -564,7 +564,7 @@ The client will then build an authorization URL using the `authorize_endpoint` o
 
 ```url
 https://bar.xzy/oauth2/authorize
-  ?client_id=bsky.app
+  ?client_id=app.example.com
   &request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3Abwc4JK-ESC0w8acc191e-Y1LTC2
 ```
 
@@ -580,15 +580,15 @@ Upon successful authorization by the user, the AS will issue an authorization co
 The client will use that code (along with [PKCE][RFC7636]), to contact the `/token` endpoint on the AS.
 
 ```http
-POST https://bsky.social/oauth/token
+POST https://entryway.example.com/oauth/token
 Content-Type: application/x-www-form-urlencoded
 DPoP: <DPOP_PROOF_JWT>
 
 grant_type=authorization_code
 &code=<AUTHORIZATION_CODE>
 &code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
-&client_id=bsky.app
-&redirect_uri=https://bsky.app/my-app/oauth-callback
+&client_id=app.example.com
+&redirect_uri=https://app.example.com/my-app/oauth-callback
 ```
 
 ```http-response
@@ -650,7 +650,7 @@ The `application_type` client metadata claim is part of [OIDC-CLIENT-REGISTRATIO
 - [DRAFT-OAUTH-BROWSER-BASED-APPS] requires exact matching of the `redirect_uri` for web apps. This rules out the use of loopback redirect uris for web apps.
 - Since AS' can be implemented to be OIDC compliant, it is important that all clients, including those that are not OIDC compliant, stay compatible with every AS. Since the default `application_type` is `web`, non OIDC compliant clients could be rejected by OIDC compliant AS, if they are using `redirect_uris` that are not allowed for `web` clients. For this reason, using Loopback or custom scheme redirect uris requires to specify `application_type` as `native`.
 
-### Should websites allow users to login with ATPROTO ?
+### Should websites allow users to login with [ATPROTO]?
 
 While technically possible it's not recommended at the current time. Clients attempting to implement such a scheme **MUST** take into account that the `sub` in the token response **cannot** be trusted without the did -> pds -> issuer resolution described in this document. Not doing this verification would allow a malicious actor to impersonate any user in the client.
 

--- a/0004-oauth/README.md
+++ b/0004-oauth/README.md
@@ -4,7 +4,7 @@ _This proposal written by Matthieu Sieben, Devin Ivy, and Daniel Holmgren, on be
 
 ## Introduction
 
-[ATPROTO] describes how decentralized entities can communicate in order to provide a world class social networking technology. Users' messages are exchanged from their own/shared Personal Data Servers (PDS) using a federated networking model.
+The [AT Protocol][ATPROTO] describes how decentralized entities can communicate in order to provide a world class social networking technology. Users' messages are exchanged from their own/shared Personal Data Servers (PDS) using a federated networking model.
 
 As of writing of this document, there are basically two ways to obtain credentials to control a user's PDS:
 
@@ -13,7 +13,7 @@ As of writing of this document, there are basically two ways to obtain credentia
 
 Only the latter method is safe to use with a third party application or service (client) that would like to act on the user's behalf. However, this method of obtaining credentials is not very user friendly and does not provide the UX end users are used to.
 
-OAuth2 is a well known, well documented framework specifically made for granting user credentials to third party clients. However, it was not initially designed to work in a fully decentralized environment, such as the [ATPROTO] network. The main issue blocking its direct adoption is that, in OAuth2, clients need to be pre-registered and known by the Authorization Server (AS) before credentials can be granted. The [OAuth 2.0 Dynamic Client Registration Protocol][RFC7591] describes how clients can dynamically register into an AS. However, this method has several disadvantages:
+OAuth2 is a well known, well documented framework specifically made for granting user credentials to third party clients. However, it was not initially designed to work in a fully decentralized environment, such as the [AT Protocol][ATPROTO] network. The main issue blocking its direct adoption is that, in OAuth2, clients need to be pre-registered and known by the Authorization Server (AS) before credentials can be granted. The [OAuth 2.0 Dynamic Client Registration Protocol][RFC7591] describes how clients can dynamically register into an AS. However, this method has several disadvantages:
 
 - Clients need to keep a state for all the AS they registered to, making them harder to implement and maintain.
 - The client credentials obtained from the AS during the registration can get lost, without any way for the clients recover them autonomously.
@@ -21,15 +21,15 @@ OAuth2 is a well known, well documented framework specifically made for granting
 
 This proposal describes an alternative way of performing client registration. This method is relies on being able derive the client metadata document from its client id, allowing clients to be registered on the fly.
 
-This proposal also describes the minimal OAuth requirements that clients and [ATPROTO] servers must implement in order to be able to interact with each other. The choices in this document are based on state of the art security practices and were largely influenced by [DRAFT-OAUTH-BROWSER-BASED-APPS].
+This proposal also describes the minimal OAuth requirements that clients and [AT Protocol][ATPROTO] servers must implement in order to be able to interact with each other. The choices in this document are based on state of the art security practices and were largely influenced by [draft-oauth-browser-based-apps][DRAFT-OAUTH-BROWSER-BASED-APPS].
 
 ### Terminology
 
-Along with the terms defined in the various RFCs listed in the [references](#references) (OAuth 2.0 [RFC6749], JSON Web Token (JWT) [RFC7519], etc.), this draft uses the terms defined hereafter:
+Along with the terms defined in the various RFCs listed in the [references](#references) (OAuth 2.0 [RFC6749][], JSON Web Token (JWT) [RFC7519][], etc.), this draft uses the terms defined hereafter:
 
-- Global client identifier: a globally unique identifier for a client. This differs from the "client identifier" defined by OAuth 2.0 [RFC6749] in the sense that, in the OAuth 2.0 framework, the client identifier is only unique for a given AS. In the current framework, we need clients to be uniquely identified across all AS' in a verifiable way. In this document, "Client ID" refers to the global client identifier of the client.
-- Personal Data Server (PDS): the "resource server" that hold end-users' data, as defined by [ATPROTO].
-- Entryway: In large PDS deployments, it is likely that users will be hosted on numerous individual PDSes. In this case, a special server, the entryway, is responsible for handling unauthenticated requests. This includes the OAuth2 authentication endpoints described in this document. The entryway will thus act as an "Authorization Server", as defined by OAuth 2.0 [RFC6749]. In smaller deployments (e.g. self-hosted PDS), the PDS and entryway may be the same entity/server.
+- Global client identifier: a globally unique identifier for a client. This differs from the "client identifier" defined by OAuth 2.0 [RFC6749][] in the sense that, in the OAuth 2.0 framework, the client identifier is only unique for a given AS. In the current framework, we need clients to be uniquely identified across all AS' in a verifiable way. In this document, "Client ID" refers to the global client identifier of the client.
+- Personal Data Server (PDS): the "resource server" that hold end-users' data, as defined by [AT Protocol][ATPROTO].
+- Entryway: In large PDS deployments, it is likely that users will be hosted on numerous individual PDSes. In this case, a special server, the entryway, is responsible for handling unauthenticated requests. This includes the OAuth2 authentication endpoints described in this document. The entryway will thus act as an "Authorization Server", as defined by OAuth 2.0 [RFC6749][]. In smaller deployments (e.g. self-hosted PDS), the PDS and entryway may be the same entity/server.
 
 ### Goals
 
@@ -42,7 +42,7 @@ The goals we try to achieve through this framework are:
 
 ## Framework
 
-In addition to the identity resolution mechanisms specified by [ATPROTO], the current framework builds on top of the following specifications and drafts:
+In addition to the identity resolution mechanisms specified by [AT Protocol][ATPROTO], the current framework builds on top of the following specifications and drafts:
 
 - [OAuth 2.0 Protected Resource Metadata draft][DRAFT-OAUTH-RESOURCE-METADATA]
 - [OAuth Client ID Metadata Document draft][DRAFT-OAUTH-CLIENT-ID-METADATA-DOCUMENT]
@@ -55,7 +55,7 @@ In addition to the identity resolution mechanisms specified by [ATPROTO], the cu
 - [JWT for Assertion Framework protocol][RFC7523] (For authenticating clients)
 - [Pushed Authorization Requests][RFC9126]
 
-When a client needs to obtain credentials to interact with a user's PDS, it must initiate an authorization flow with the PDS's Authorization Server (AS). In order to determine the AS's authorization metadata, the client must first resolve the PDS's URI from the user's handle (see [ATPROTO]). Once the PDS URI is known (e.g. `https://pds.example.com`), the [protected resource metadata][DRAFT-OAUTH-RESOURCE-METADATA] document will allow the client to obtain the Authorization Server Issuer from the `authorization_servers` field. The [Authorization Server Metadata][RFC8414] endpoint (`<PDS_ORIGIN>/.well-known/oauth-authorization-server`) will allow the client to obtain all the information it needs to initiate an OAuth2 authorization flow (see the [server metadata](#server-metadata) section below).
+When a client needs to obtain credentials to interact with a user's PDS, it must initiate an authorization flow with the PDS's Authorization Server (AS). In order to determine the AS's authorization metadata, the client must first resolve the PDS's URI from the user's handle (see [AT Protocol][ATPROTO]). Once the PDS URI is known (e.g. `https://pds.example.com`), the [protected resource metadata][DRAFT-OAUTH-RESOURCE-METADATA] document will allow the client to obtain the Authorization Server Issuer from the `authorization_servers` field. The [Authorization Server Metadata][RFC8414] endpoint (`<PDS_ORIGIN>/.well-known/oauth-authorization-server`) will allow the client to obtain all the information it needs to initiate an OAuth2 authorization flow (see the [server metadata](#server-metadata) section below).
 
 Clients do not need to be pre-registered with the Authorization Server. Instead, the Authorization Server will dynamically load the [client metadata document][DRAFT-OAUTH-CLIENT-ID-METADATA-DOCUMENT] from the `client_id`, during an authorization request, as described in the [client metadata](#client-metadata) section. The client metadata is a JSON file that contains the client's metadata (name, logo, allowed redirect URIs, expected scopes, JWKS, etc.). The content of that document is based on the [OAuth 2.0 Dynamic Client Registration Protocol][RFC7591] and [OAuth 2.0 Dynamic Client Registration Management Protocol][RFC7592] specifications.
 
@@ -63,7 +63,7 @@ Since clients do not pre-register themselves with the Authorization Server, they
 
 This framework requires the following specifications to be used during the authorization flow:
 
-- PAR: Pushed Authorization Requests ([RFC9126]). Because of the reasons listed hereafter, and because of the added security it provides, the use of PAR is **mandatory** for all clients. Frontend client must also use (unauthenticated) PAR requests.
+- PAR: Pushed Authorization Requests ([RFC9126][]). Because of the reasons listed hereafter, and because of the added security it provides, the use of PAR is **mandatory** for all clients. Frontend client must also use (unauthenticated) PAR requests.
 
   > Note: In the future, we might relax this requirement for frontend clients, but for now, we want to keep things simple & consistent across all clients.
 
@@ -71,9 +71,9 @@ This framework requires the following specifications to be used during the autho
   - PAR allows clients to send a very large authorization request payload (e.g. a request object containing a lot of claims) without having to worry about URL length limitations.
   - PAR improves security and privacy by allowing clients to send sensitive information (e.g. `code_verification`, etc.) directly to the Authorization Server, without having to send this data through the front channel.
 
-- PKCE: Proof Key for Code Exchange ([RFC7636]), which is part of the [OAuth2.1 draft][DRAFT-OAUTH-V2-1]. It is used to prevent any entity, other than the one that initiated the authorization request, to exchange the authorization code for an access token. The main impact of this choice is that the implicit grant type **must not** allow clients to obtain access tokens. Instead, all clients **must** contact the "token endpoint" after they are redirected from the "authorization endpoint" in order to obtain an access token. The OAuth client performing the authorization flow must be able to store a session securely. Only the `S256` challenge method is allowed by this specification. In the future, we might allow `plain` challenge method, but only for authenticated clients.
+- PKCE: Proof Key for Code Exchange ([RFC7636][]), which is part of the [OAuth2.1 draft][DRAFT-OAUTH-V2-1]. It is used to prevent any entity, other than the one that initiated the authorization request, to exchange the authorization code for an access token. The main impact of this choice is that the implicit grant type **must not** allow clients to obtain access tokens. Instead, all clients **must** contact the "token endpoint" after they are redirected from the "authorization endpoint" in order to obtain an access token. The OAuth client performing the authorization flow must be able to store a session securely. Only the `S256` challenge method is allowed by this specification. In the future, we might allow `plain` challenge method, but only for authenticated clients.
 
-- DPoP: Demonstrating Proof of Possession ([RFC9449]) is used to **bind** tokens (access tokens & refresh tokens) to a client instance that holds a specific private key. This is done by providing a "proof of possession" when requesting for new tokens. The Authorization token will then issue a "sender-constrained" Access Token (the public DPoP key of the client is included in the access token). The client instance will then be able to access the resource server (PDS) by providing **both** the access token and a recently generated DPoP proof. This mechanism protects against token theft and replay attacks.
+- DPoP: Demonstrating Proof of Possession ([RFC9449][]) is used to **bind** tokens (access tokens & refresh tokens) to a client instance that holds a specific private key. This is done by providing a "proof of possession" when requesting for new tokens. The Authorization token will then issue a "sender-constrained" Access Token (the public DPoP key of the client is included in the access token). The client instance will then be able to access the resource server (PDS) by providing **both** the access token and a recently generated DPoP proof. This mechanism protects against token theft and replay attacks.
 
 The general framework is described in figure 1.
 
@@ -131,7 +131,7 @@ The general framework is described in figure 1.
 
 Figure 1.: Authorization flow for a client. Note that neither the client nor the authorization server necessarily know about each other before the authorization flow is initiated.
 
-First step (1) is for the client to ask the user for their [ATPROTO] handle, or, should they have forgotten their handle, their PDS or Entryway's URL (e.g. `pds.example.com`). The client will then fetch (3) and validate (4) the Authorization Server Metadata using the method described [below](#server-metadata).
+First step (1) is for the client to ask the user for their [AT Protocol][ATPROTO] handle, or, should they have forgotten their handle, their PDS or Entryway's URL (e.g. `pds.example.com`). The client will then fetch (3) and validate (4) the Authorization Server Metadata using the method described [below](#server-metadata).
 
 The client will then build (5) the authorization URL using [PAR][RFC9126] & [PKCE][RFC7636]. This will cause the Authorization Server to load and validate the client metadata (6) using the method described [below](#client-metadata). Once the authorization request is successfully created, the end user will be redirected to the authorize endpoint (7, 8).
 
@@ -141,15 +141,15 @@ Whenever receiving a request for a particular client, the Authorization Server *
 - Load & verify the client metadata, deduced from the client ID (see the [client metadata](#client-metadata) section)
 - Verify that the authorization request is compliant with the current spec (see the [authorization request](#authorization-request) section)
 
-During the user authorization step (10), if the user never approved a request from a particular client, the [AUTH-UI] will contain any relevant information required for the user to be able to make an informed decision (see the [Impersonation](#impersonation) section below). Note that if the client was authenticated during PAR (step 5), the Authorization Server can decide to grant an increased level of trust to the client, and thus skip some of the authorization UI steps. For example, AS's **should not** allow silent sign on for unauthenticated clients. Similarly, the AS **should** always require user consent for unauthenticated clients (even if consent was already granted before).
+During the user authorization step (10), if the user never approved a request from a particular client, the [Authorization Interface][AUTH-UI] will contain any relevant information required for the user to be able to make an informed decision (see the [Impersonation](#impersonation) section below). Note that if the client was authenticated during PAR (step 5), the Authorization Server can decide to grant an increased level of trust to the client, and thus skip some of the authorization UI steps. For example, AS's **should not** allow silent sign on for unauthenticated clients. Similarly, the AS **should** always require user consent for unauthenticated clients (even if consent was already granted before).
 
 During token retrieval (12), the Authorization Server **must** ensure the Token Request is compliant with the current spec (see the [token request](#token-request) section).
 
-In addition to the requested tokens, the token response must also contain, in the `sub` claim, the user's [ATPROTO] distributed identifier (DID). This value will allow clients to resolve the PDS url using the [DID-PLC] resolution method. If the authorization request was initiated (in step 1) using the user's `@handle`, the client **must** verify that the token response's `sub` claim matches the DID that was resolved from this handle. If no `@handle` was provided when initiating the flow, the client **MUST** perform the [DID-PLC] + Issuer resolution mechanism using the token response's `sub`. This is done to verify that the `iss` of the token response matches the `issuer` from the Authorization Server Metadata resolved from the DID. It is critical that the client checks that the `sub` is indeed hosted and managed by the `iss`, and vice versa, whenever a token response is received.
+In addition to the requested tokens, the token response must also contain, in the `sub` claim, the user's [AT Protocol][ATPROTO] distributed identifier (DID). This value will allow clients to resolve the PDS url using the [DID-PLC] resolution method. If the authorization request was initiated (in step 1) using the user's `@handle`, the client **must** verify that the token response's `sub` claim matches the DID that was resolved from this handle. If no `@handle` was provided when initiating the flow, the client **MUST** perform the [DID-PLC] + Issuer resolution mechanism using the token response's `sub`. This is done to verify that the `iss` of the token response matches the `issuer` from the Authorization Server Metadata resolved from the DID. It is critical that the client checks that the `sub` is indeed hosted and managed by the `iss`, and vice versa, whenever a token response is received.
 
 In addition to being bound to the client's DPoP key, all tokens issued by the AS will also be bound to the public key used by the client to authenticate itself through the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant (only for public client). If, at any point, a client stops advertising a public key that is used in active sessions, all those sessions will be invalidated. The AS will choose, at its discretion how it will implement this (proactively, whenever metadata are fetched, on the next token refresh, etc.).
 
-Because frontend only apps are not able to provide a similar mechanism to invalidate credentials at scale, [DRAFT-OAUTH-BROWSER-BASED-APPS] requires that refresh tokens "MUST set a maximum lifetime [...] or expire if they are not used in some amount of time". As an additional restriction, unauthenticated clients are not allowed use silent sign on. This means that the user will have to give its consent again (but _not_ necessarily re-authenticate itself if he still has an active session on the AS) to the client every time a period of inactivity is reached. In practice, after some inactivity period, the user will be redirected to the authorization server to re-authorize the client with a message saying: "You have been inactive for 48 hours on `app.example.com`. You are still authenticated as John Doe. To continue, please re-authorize the `app.example.com` to access your account by clicking this button".
+Because frontend only apps are not able to provide a similar mechanism to invalidate credentials at scale, [draft-oauth-browser-based-apps][DRAFT-OAUTH-BROWSER-BASED-APPS] requires that refresh tokens "MUST set a maximum lifetime [...] or expire if they are not used in some amount of time". As an additional restriction, unauthenticated clients are not allowed use silent sign on. This means that the user will have to give its consent again (but _not_ necessarily re-authenticate itself if he still has an active session on the AS) to the client every time a period of inactivity is reached. In practice, after some inactivity period, the user will be redirected to the authorization server to re-authorize the client with a message saying: "You have been inactive for 48 hours on `app.example.com`. You are still authenticated as John Doe. To continue, please re-authorize the `app.example.com` to access your account by clicking this button".
 
 Authenticated clients **should** rotate their keys on a regular basis (e.g. on every new app release, or every month, whichever comes first). They can do so by adding a new key to their JWKS and removing the old ones from time to time. If a breach is detected, the client **must** immediately remove the compromised key from its JWKS. If the mitigation of the breach takes long, all the keys **must** be removed from the JWKS as the issue is being fixed, preventing any new tokens from being issued.
 
@@ -167,12 +167,12 @@ Authorization Server **must not** accept client IDs that are not compliant with 
 
 ### Client metadata
 
-Instead of relying on dynamic client registration, clients will be automatically/lazily registered by the AS when they first initiate an authorization flow. In order to do so, the AS will need to be able to resolve the the client metadata document as described by [[DRAFT-OAUTH-CLIENT-ID-METADATA-DOCUMENT]].
+Instead of relying on dynamic client registration, clients will be automatically/lazily registered by the AS when they first initiate an authorization flow. In order to do so, the AS will need to be able to resolve the the client metadata document as described by [draft-oauth-client-id-metadata-document][DRAFT-OAUTH-CLIENT-ID-METADATA-DOCUMENT].
 
-In addition to be conformant with the Client Metadata described in [RFC7591], the following rules also apply to the client metadata document. These rules **must** be enforced by the AS.
+In addition to be conformant with the Client Metadata described in [RFC7591][], the following rules also apply to the client metadata document. These rules **must** be enforced by the AS.
 
 - the metadata **must** contain `client_id`, and this value **must** be strictly equal to the client id that was used to resolve this document.
-- the metadata **must** contain `"dpop_bound_access_tokens": true`. All clients must use [DPoP][RFC9449] proof when requesting tokens.
+- the metadata **must** contain `"dpop_bound_access_tokens": true`. All clients must use DPoP ([RFC9449][]) proof when requesting tokens.
 - the metadata **must** contain at least one `redirect_uris` entry.
 - the `application_type`, if present, **must** either be `"web"` or `"native"` (default is `web`).
 - `"web"` clients must use HTTPS for all their `redirect_uris`.
@@ -187,7 +187,7 @@ In addition to be conformant with the Client Metadata described in [RFC7591], th
 - the `response_types` metadata **must** contain `code`. Other response types can be added (e.g. `id_token`) but won't necessarily be supported by the AS.
 - the `scope` metadata **must** contain `offline_access` if, and only if, `refresh_token` is present in `grant_types`.
 - the `scope` metadata can be used to restrict which scopes are allowed during the authorization flow for that client. No scope are allowed by default.
-- the `response_types` _may_ contain `"token"`. However, since [PKCE][RFC7636] is mandatory for all exchanges, AS **must** only allow `"token"` response type to be used when PKCE is irrelevant (such as during the `password` grant type).
+- the `response_types` _may_ contain `"token"`. However, since PKCE ([RFC7636][]) is mandatory for all exchanges, AS **must** only allow `"token"` response type to be used when PKCE is irrelevant (such as during the `password` grant type).
 - every `token_endpoint_auth_method` (where `<endpoint>` is `token`, `revocation`, `introspection`), if present, **must** be set to `private_key_jwt` or `none`.
 - if any of the `token_endpoint_auth_method` is set to `private_key_jwt`, the client **must** provide a JSON web key set (JWKS), either through the `jwks` metadata or through the `jwks_uri` metadata, that contains at least one key.
 - `jwks` and `jwks_uri` **must not** be used together.
@@ -222,7 +222,7 @@ if (origin === 'http://localhost') {
 }
 
 if (protocol === 'https:') {
-  // [DRAFT-OAUTH-CLIENT-ID-METADATA-DOCUMENT]
+  // draft-oauth-client-id-metadata-document
   return fetchAndValidateMetadataDocument(clientId)
 }
 
@@ -231,13 +231,13 @@ if (protocol === 'https:') {
 
 ### Server Metadata
 
-In order to retrieve the AS metadata, the client will first need to obtain the PDS URL (using [ATPROTO]'s resolution mechanism). The PDS URL (e.g. `https://pds.example`) being a resource server, the client will need to fetch the [protected resource metadata document][DRAFT-OAUTH-RESOURCE-METADATA] (by appending `/.well-known/oauth-protected-resource` to the PDS URL). That document MUST contain a single item in the `authorization_servers` array. This issuer identifier (e.g. `https://entryway.example`) will allow the client to fetch the Authorization Server Metadata (By appending `/.well-known/oauth-authorization-server` to the issuer). All the documents **must** be returned with a 200 HTTP status code and a `application/json` content-type. Any other status code or content-type **must** result in an error.
+In order to retrieve the AS metadata, the client will first need to obtain the PDS URL (using [AT Protocol][ATPROTO]'s resolution mechanism). The PDS URL (e.g. `https://pds.example`) being a resource server, the client will need to fetch the [protected resource metadata document][DRAFT-OAUTH-RESOURCE-METADATA] (by appending `/.well-known/oauth-protected-resource` to the PDS URL). That document MUST contain a single item in the `authorization_servers` array. This issuer identifier (e.g. `https://entryway.example`) will allow the client to fetch the Authorization Server Metadata (By appending `/.well-known/oauth-authorization-server` to the issuer). All the documents **must** be returned with a 200 HTTP status code and a `application/json` content-type. Any other status code or content-type **must** result in an error.
 
 Note that a user's `@handle` or DID is _not_ required to initiate this flow. The client can cut short the "handle -> did -> pds url -> authorisation server url" process by starting at any step (depending on user input). For example, if the client detects that the user used an HTTPS url as input, it can try to obtain the [protected resource metadata document][DRAFT-OAUTH-RESOURCE-METADATA], and continue the resolution process from there. If that fails, the client can then try to interpret the input as being an authorization server's issuer in order to obtain the metadata document.
 
 Once the client retrieved the Authorization Server Metadata, it **must** verify the following items. Any authorization flow with an AS not compliant with these rules **must** be rejected by the client.
 
-- `issuer` **must** be a valid URL on the same origin as the URL that was used to fetch the document. If a redirection occurred, the URL of the last HTTP request **must** be used to check the metadata's `issuer` (see [DRAFT-OAUTH-SECURITY-TOPICS] section 4.4).
+- `issuer` **must** be a valid URL on the same origin as the URL that was used to fetch the document. If a redirection occurred, the URL of the last HTTP request **must** be used to check the metadata's `issuer` (see [draft-oauth-security-topics][DRAFT-OAUTH-SECURITY-TOPICS] section 4.4).
 - `issuer` **must** be an HTTPS URL in the form `https://<domain>[:<port>]/`. The port **must** be omitted if it is the default port for the scheme (e.g. `443` for `https`). The `http:` scheme **must not** be used.
 - `response_types_supported` **must** at least contain `code`.
 - `grant_types_supported` **must** at least contain `authorization_code` and `refresh_token`.
@@ -246,12 +246,12 @@ Once the client retrieved the Authorization Server Metadata, it **must** verify 
 - `token_endpoint_auth_signing_alg_values_supported` **must** contain `ES256`.
 - `scopes_supported` **must** contain `refresh_token`, `email`, `profile`.
 - `subject_types_supported`, if present, **must** contain `public`.
-- `authorization_response_iss_parameter_supported` **must** be `true`. Both AS' and clients **must** be [RFC9207] compliant.
-- `pushed_authorization_request_endpoint` **must** be set. Both AS' and clients **must** be [RFC9126] compliant.
+- `authorization_response_iss_parameter_supported` **must** be `true`. Both AS' and clients **must** be [RFC9207][] compliant.
+- `pushed_authorization_request_endpoint` **must** be set. Both AS' and clients **must** be [RFC9126][] compliant.
 - `require_pushed_authorization_requests` **must** be set to `true`.
 - `dpop_signing_alg_values_supported` **must** be set and contain `ES256`.
 - `require_request_uri_registration`, if present, **must** be `true`.
-- `client_id_metadata_document_supported` **must** be set to `true` (per [[DRAFT-OAUTH-CLIENT-ID-METADATA-DOCUMENT]]).
+- `client_id_metadata_document_supported` **must** be set to `true` (per [draft-oauth-client-id-metadata-document][DRAFT-OAUTH-CLIENT-ID-METADATA-DOCUMENT]).
 
 The client **must** also comply with the definitions of these fields, as defined by their authoritative specifications.
 
@@ -262,19 +262,19 @@ In addition to the [OAuth 2.0 Security Best Current Practice][DRAFT-OAUTH-SECURI
 - The following scopes **must** be supported: `email`, `profile`, `offline_access`
 - The `code` response type **must** be supported.
 - The `ES256` JWT verification algorithm must be supported for any JWT verification (e.g. `client_assertion`, `dpop` proof, etc.)
-- [Pushed Authorization Request][RFC9126] **must** be enforced (`require_pushed_authorization_requests` in the server metadata must be `true`).
-- The [Pushed Authorization Request][RFC9126] endpoint **must** support the same authentication methods as the token endpoint (namely `private_key_jwt` and `none`).
+- Pushed Authorization Request ([RFC9126][]) **must** be enforced (`require_pushed_authorization_requests` in the server metadata must be `true`).
+- The Pushed Authorization Request ([RFC9126][]) endpoint **must** support the same authentication methods as the token endpoint (namely `private_key_jwt` and `none`).
 - grant types: `authorization_code` & `refresh_token`
 - Response modes: `fragment`, `query`, `form_post`
 - The Token & PAR Endpoints **must** support the `none` & `private_key_jwt` Authentication Methods.
 - They **must** require PKCE for all authentication requests.
-- The `code_challenge_methods_supported` server metadata ([PKCE][RFC7636]) **must** contain `RS256`. The AS _should not_ allow the `plain` challenge method to be used.
+- The `code_challenge_methods_supported` server metadata (PKCE [RFC7636][]) **must** contain `RS256`. The AS _should not_ allow the `plain` challenge method to be used.
 - They **must** require DPoP for all tokens requests. They **must** support DPoP for authorization requests.
 - Access tokens **must** have a maximum lifetime of 1 hour.
 - The OAuth authorization server metadata must be expose through the `oauth-authorization-server` well-known endpoint (see the [server metadata](#server-metadata) section)
 - Unauthenticated clients **must not** be issued refresh tokens with a total lifetime longer than 48 hours
 - refresh tokens **must** be bound to the client's DPoP key
-- refresh tokens **should** be rotated any time they are used. If a previous refresh token is replayed, the AS **must** revoke the currently active refresh token. See [DRAFT-OAUTH-SECURITY-TOPICS] (section 4.14.2).
+- refresh tokens **should** be rotated any time they are used. If a previous refresh token is replayed, the AS **must** revoke the currently active refresh token. See [draft-oauth-security-topics][DRAFT-OAUTH-SECURITY-TOPICS] (section 4.14.2).
 
 ### Authorization Request
 
@@ -296,7 +296,7 @@ The following rules must be enforced by the AS when receiving a token request.
 - Public clients **must** generate a new keypair for each set of tokens they request. Authorization servers **should** reject initial tokens requests from public clients that use the same keypair as a previous request.
 - Ensure that the client authentication method is the same as the one used during PAR (if `client_assertion` was used during PAR, the same authentication method **must** be used, with a JWT containing a distinct `jti` claim, but signed by the same key)
 - DPoP proof and client assertion **must** be signed using a different keypair.
-- The Token Response from the AS **must** contain a `sub` claim, which must be the end-user's [ATPROTO] DID (`did:plc:123`)
+- The Token Response from the AS **must** contain a `sub` claim, which must be the end-user's [AT Protocol][ATPROTO] DID (`did:plc:123`)
 
 ## Supported architectures
 
@@ -329,7 +329,7 @@ In this architecture, all secrets are kept on the backend. This means that the a
 +-----------------+         +-------------------------------------------------+
 ```
 
-This figure was taken from the section 6.1.1 of [DRAFT-OAUTH-BROWSER-BASED-APPS]. It shows that the backend is the only entity that can contact the resource server (PDS). It can do so either on its own (from a background worker) or on behalf of a user (by proxying the requests).
+This figure was taken from the section 6.1.1 of [draft-oauth-browser-based-apps][DRAFT-OAUTH-BROWSER-BASED-APPS]. It shows that the backend is the only entity that can contact the resource server (PDS). It can do so either on its own (from a background worker) or on behalf of a user (by proxying the requests).
 
 In this architecture, the authorization flow works as follows:
 
@@ -380,7 +380,7 @@ These proofs will be used both when requesting the new tokens through the backen
 +-----------------+         +-------------------------------------------------+
 ```
 
-This figure was taken from the section 6.2.1 of [DRAFT-OAUTH-BROWSER-BASED-APPS]. In this scenario, the browser obtains tokens from the Token-Mediating Backend and uses them to access the Resource Server (J).
+This figure was taken from the section 6.2.1 of [draft-oauth-browser-based-apps][DRAFT-OAUTH-BROWSER-BASED-APPS]. In this scenario, the browser obtains tokens from the Token-Mediating Backend and uses them to access the Resource Server (J).
 
 In this architecture, the authorization flow works as follows:
 
@@ -426,7 +426,7 @@ In this architecture, the client is a frontend only app. It can be a mobile app,
 +-----------------+         +-------------------------------+
 ```
 
-This figure was taken from the section 6.3.1 of [DRAFT-OAUTH-BROWSER-BASED-APPS]. We can see the Browser negotiating with the Authorization Server (B), and then interacting directly with the Resource Server (D,E).
+This figure was taken from the section 6.3.1 of [draft-oauth-browser-based-apps][DRAFT-OAUTH-BROWSER-BASED-APPS]. We can see the Browser negotiating with the Authorization Server (B), and then interacting directly with the Resource Server (D,E).
 
 The client metadata **must not** contain any public key (JWKS) as the client, being "serverless", has no way to securely store & use any private key.
 
@@ -527,7 +527,7 @@ Refresh tokens will later be used in order to obtain new access tokens. These re
 
 ### Authorization flow from a serverless browser app
 
-In this mode, the browser will act as a public client. This is essentially the flow described in section 6.3 of [DRAFT-OAUTH-BROWSER-BASED-APPS]. The reason why we want to support the least secure option from the book is because we want to allow client developers to create simple serverless apps for the Atproto ecosystem.
+In this mode, the browser will act as a public client. This is essentially the flow described in section 6.3 of [draft-oauth-browser-based-apps][DRAFT-OAUTH-BROWSER-BASED-APPS]. The reason why we want to support the least secure option from the book is because we want to allow client developers to create simple serverless apps for the Atproto ecosystem.
 
 The client starts by resolving Authorization Server Metadata as described [before](#server-metadata).
 
@@ -606,7 +606,7 @@ Cache-Control: no-store
 
 The AS will make all necessary checks (PKCE, request expiration, etc.) to ensure that the request is valid and issue a new access token and a refresh token.
 
-See [DRAFT-OAUTH-BROWSER-BASED-APPS] (section 6.3.2.5) and [DRAFT-OAUTH-SECURITY-TOPICS] (section 4.14.2), for more details on the restriction that **must** be applied to the refresh tokens.
+See [draft-oauth-browser-based-apps][DRAFT-OAUTH-BROWSER-BASED-APPS] (section 6.3.2.5) and [draft-oauth-security-topics][DRAFT-OAUTH-SECURITY-TOPICS] (section 4.14.2), for more details on the restriction that **must** be applied to the refresh tokens.
 
 ## Security
 
@@ -646,11 +646,11 @@ Yes. There is nothing in this spec that prevents the Authorization Server to be 
 
 The `application_type` client metadata claim is part of [OIDC-CLIENT-REGISTRATION] and not part of [Dynamic Client Registration Protocol][RFC7591]. While this spec does not require OIDC compatibility, that particular claim was added for the following reasons:
 
-- [DRAFT-OAUTH-SECURITY-TOPICS] distinguishes security practices for native & web apps.
-- [DRAFT-OAUTH-BROWSER-BASED-APPS] requires exact matching of the `redirect_uri` for web apps. This rules out the use of loopback redirect uris for web apps.
+- [draft-oauth-security-topics][DRAFT-OAUTH-SECURITY-TOPICS] distinguishes security practices for native & web apps.
+- [draft-oauth-browser-based-apps][DRAFT-OAUTH-BROWSER-BASED-APPS] requires exact matching of the `redirect_uri` for web apps. This rules out the use of loopback redirect uris for web apps.
 - Since AS' can be implemented to be OIDC compliant, it is important that all clients, including those that are not OIDC compliant, stay compatible with every AS. Since the default `application_type` is `web`, non OIDC compliant clients could be rejected by OIDC compliant AS, if they are using `redirect_uris` that are not allowed for `web` clients. For this reason, using Loopback or custom scheme redirect uris requires to specify `application_type` as `native`.
 
-### Should websites allow users to login with [ATPROTO]?
+### Should websites allow users to login with [AT Protocol][ATPROTO]?
 
 While technically possible it's not recommended at the current time. Clients attempting to implement such a scheme **MUST** take into account that the `sub` in the token response **cannot** be trusted without the did -> pds -> issuer resolution described in this document. Not doing this verification would allow a malicious actor to impersonate any user in the client.
 

--- a/0004-oauth/README.md
+++ b/0004-oauth/README.md
@@ -179,7 +179,7 @@ In addition to be conformant with the Client Metadata described in [RFC7591], th
 - redirect uri using the `https:` scheme **must** be on the same origin as the client, regardless of the the `application_type`.
 - redirect uri using the `http:` scheme are only allowed for `"native"` clients.
 - redirect uri using the `http:` scheme **must** use either `127.0.0.1` or `[::1]` in their hostname component. Any other hostname (including `localhost`) is forbidden. The port **must not** be specified as the AS will allow any port when validating loopback redirect uris.
-- `"native"` clients are allowed to specify redirect uris using custom schemes (e.g. `app.bsky:/callback`). The custom scheme **must** be the reverted domain name of the client (e.g. `com.example.app:` when the client id is `app.example.com`), and must contain at least one `.` character.
+- `"native"` clients are allowed to specify redirect uris using custom schemes (e.g. `app.bsky:/callback`). The custom scheme **must** be the reverted domain name of the client (e.g. `com.example.app:` when the client id is `https://app.example.com/client-metadata.json`), and must contain at least one `.` character.
 - When custom schemes are used in redirect uri, only a single slash (`/`) character is allowed after the scheme (e.g. `app.bsky:/callback` is allowed, but `app.bsky://callback` is not).
 - the `client_uri` metadata, if present, **must** be on the same origin as the URL derived from the client ID.
 - the `subject_type` metadata, if present, **must** be `"public"`.
@@ -460,11 +460,11 @@ Content-Type: application/x-www-form-urlencoded
 response_type=code
 &code_challenge=K2-ltc83acc4h0c9w6ESC_rEMTJ3bww-uCHaoeK1t8U
 &code_challenge_method=S256
-&client_id=app.example.com
+&client_id=https%3A%2F%2Fapp.example.com%2Fclient-metadata.json
 &state=duk681S8n00GsJpe7n9boxdzen
-&redirect_uri=https://app.example.com/my-app/oauth-callback
-&scope=scope_a scope_b scope_c
-&login_hint=did:plc:123
+&redirect_uri=https%3A%2F%2Fapp.example.com%2Fmy-app%2Foauth-callback
+&scope=scope_a%20scope_b%20scope_c
+&login_hint=did%3Aplc%3A123
 &client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
 &client_assertion=<SELF_SIGNED_JWT>
 ```
@@ -485,7 +485,7 @@ Content-Type: application/json
 The client will then redirect the user to the authorize endpoint using the `request_uri` obtained from the previous step. The AS will verify that the `request_uri` is still valid. Here is what the authorization URL will look like:
 
 ```url
-https://entryway.example.com/oauth/authorize?client_id=app.example.com&request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3Abwc4JK-ESC0w8acc191e-Y1LTC2
+https://entryway.example.com/oauth/authorize?client_id=https%3A%2F%2Fapp.example.com%2Fclient-metadata.json&request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3Abwc4JK-ESC0w8acc191e-Y1LTC2
 ```
 
 The AS will then authenticate the user and ask them to approve the request. Silent sign-on will only be used if the user already has a session on the AS with the same DID as the one defined in the `login_hint` parameter of the PAR request.
@@ -502,8 +502,8 @@ DPoP: <DPOP_PROOF_JWT>
 grant_type=authorization_code
 &code=<AUTHORIZATION_CODE>
 &code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
-&client_id=app.example.com
-&redirect_uri=https://app.example.com/my-app/oauth-callback
+&client_id=https%3A%2F%2Fapp.example.com%2Fclient-metadata.json
+&redirect_uri=https%3A%2F%2Fapp.example.com%2Fmy-app%2Foauth-callback
 &client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
 &client_assertion=<SELF_SIGNED_JWT>
 ```
@@ -521,7 +521,7 @@ Cache-Control: no-store
 }
 ```
 
-The AS will bind those tokens to the `client_id` and the public key used to authenticate the client. The validity of the access token will be limited to a short period of time (e.g. 1 hour). The validity of the refresh token **must** be limited to a short period of time (e.g. 24 hours) or expire if they are not used in some amount of time (e.g. 24 hours). The AS **can** use longer pariods for authenticated clients but **must not** allow refresh tokens without a limited lifetime.
+The AS will bind those tokens to the `client_id` and the public key used to authenticate the client. The validity of the access token will be limited to a short period of time (e.g. 1 hour). The validity of the refresh token **must** be limited to a short period of time (e.g. 24 hours) or expire if they are not used in some amount of time (e.g. 24 hours). The AS **can** use longer periods for authenticated clients but **must not** allow refresh tokens without a limited lifetime.
 
 Refresh tokens will later be used in order to obtain new access tokens. These requests on the `token_endpoint` must be authenticated using the same method (JWT for Assertion Framework protocol ([RFC7523])). the same DPoP key must be presented in the `DPoP` header of the request.
 
@@ -540,11 +540,11 @@ Content-Type: application/x-www-form-urlencoded
 response_type=code
 &code_challenge=K2-ltc83acc4h0c9w6ESC_rEMTJ3bww-uCHaoeK1t8U
 &code_challenge_method=S256
-&client_id=app.example.com
+&client_id=https%3A%2F%2Fapp.example.com%2Fclient-metadata.json
 &state=duk681S8n00GsJpe7n9boxdzen
-&redirect_uri=https://app.example.com/my-app/oauth-callback
-&scope=scope_a scope_b scope_c
-&login_hint=did:plc:123
+&redirect_uri=https%3A%2F%2Fapp.example.com%2Fmy-app%2Foauth-callback
+&scope=scope_a%20scope_b%20scope_c
+&login_hint=did%3Aplc%3A123
 ```
 
 Note that the client **must** bind the `state` parameter to the issuer of the authorization request. This is required to properly verify the `iss` parameter in the authorization response (see [RFC9207]).
@@ -564,7 +564,7 @@ The client will then build an authorization URL using the `authorize_endpoint` o
 
 ```url
 https://bar.xzy/oauth2/authorize
-  ?client_id=app.example.com
+  ?client_id=https%3A%2F%2Fapp.example.com%2Fclient-metadata.json
   &request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3Abwc4JK-ESC0w8acc191e-Y1LTC2
 ```
 
@@ -587,8 +587,8 @@ DPoP: <DPOP_PROOF_JWT>
 grant_type=authorization_code
 &code=<AUTHORIZATION_CODE>
 &code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
-&client_id=app.example.com
-&redirect_uri=https://app.example.com/my-app/oauth-callback
+&client_id=https%3A%2F%2Fapp.example.com%2Fclient-metadata.json
+&redirect_uri=https%3A%2F%2Fapp.example.com%2Fmy-app%2Foauth-callback
 ```
 
 ```http-response


### PR DESCRIPTION
Updates markdown reference link format. The "just brackets" style (`[PROTOCOL]`) does work in CommonMark and is called "shortcut reference link", but when I first looked in github markdown docs it wasn't described/specced anywhere so I updated everything in "collapsed referenced link" style (`[PROTOCOL][]`) or expanded (`[Protocol][PROTOCOL]`). I'd be fine with the "shortcut reference link" syntax in the future, but doesn't seem work re-updating this PR.

The "title" string in quotes in the reference link definitions only shows up as "title" attribution not the text, unfortunately, so I updated a bunch of links with casing and/or terminology changes.

Lower-casing draft names is the norm in the IETF community so I went with that.

Updated `client_id` examples to be full URLs to a metadata JSON doc.

Updated HTTP request snippets to use urlencoding more consistently. More technically correct though poor for readability.

Removed some refs which seemed unrelated, like Open Graph and some internal notion links.

Switched domain examples to not be `bsky` in most cases, so this will read as more atproto-generic. Didn't update the reverse-domain app prefix examples as they are a good example there though.

We should maybe have a Changelog section for this doc? but I just want to get these fixes through for now, history is in git.