### PR TITLE
0016 Permissioned Data: document `manage` in space permission-set permissions

### DIFF
--- a/0016-permissioned-data/README.md
+++ b/0016-permissioned-data/README.md
@@ -506,7 +506,7 @@ Space permissions can also be bundled, usually with more user-friendly verbiage,
 }
 ```
 
-Within a permission, `"type": "permission"` is the entry discriminator, `"resource": "space"` selects the space resource, and the remaining fields carry the same parameters as the `space:` scope string: `spaceType`, `authority`, `skey`, `collection`, and `action`.
+Within a permission, `"type": "permission"` is the entry discriminator, `"resource": "space"` selects the space resource, and the remaining fields carry the same parameters as the `space:` scope string: `spaceType`, `authority`, `skey`, `collection`, `action`, and `manage`.
 
 A set permission must name a concrete space type. In other words, the `spaceType` parameter may **not** be a wildcard inside a permission set. The other parameters may still be wildcards, including `authority` and `collection`. A cross-type grant (`spaceType=*`) is expressible only as a standalone `space:` scope requested directly.
 


### PR DESCRIPTION
## What

Adds `manage` to the list of space-scope parameters a permission-set permission may
carry. One line, in **OAuth scopes → Permission sets**.

## Why

The Matching section already specifies `manage` completely for scope strings: it takes
`create`/`update`/`delete` applied to the space rather than its records, it ignores
`collection`, and it is omitted by default so an ordinary record-access grant confers no
administrative capability. The scope-string examples use it, including
`space:com.atmoboards.forum?authority=*&action=read_self&manage=update&manage=delete`.

The permission-set section then enumerates the fields a set permission may carry and
lists `spaceType`, `authority`, `skey`, `collection`, and `action` — omitting `manage`.
Because that sentence says the fields "carry the same parameters as the `space:` scope
string", the omission reads two ways: as an oversight, or as a deliberate restriction
that management is requestable only as a standalone scope. The section does state one
such restriction explicitly a paragraph later (`spaceType` may not be a wildcard inside a
set), which makes the silence on `manage` easy to read as intentional.

At least one implementation took the second reading and dropped the field. The failure
mode is the bad one: publishing the set succeeds, consent succeeds and displays an
honest description with no management in it, and the client then gets 403s on space
management at use time, having believed it asked for and received the capability. Under
the first reading the same set works. Both implementations are defensible against the
current text, which is the argument for pinning it down.

This documents support, which I believe is the intended reading — `manage` in a set is
bounded by the rules already in the spec: the set must name a concrete `spaceType`,
`authority` defaults to `self`, and what each verb permits is the space-management
implementation's business (in `simplespace`, the authority's own ownership check).
Happy to invert this to an explicit prohibition instead if that was the intent; the point
is that the text should say which.

## What this does not change

- No new semantics. `manage` behaves in a set exactly as it does in a scope string,
  including omitted-by-default, and the "same parameters" phrasing already carries that
  across — so nothing about defaults is restated here.
- No change to the concrete-`spaceType` rule, the namespace-authority requirement, or
  the `collection` dynamic-update semantics.
- The example JSON is left alone: it illustrates a read-and-post grant, and adding
  management to it would misrepresent the capability being shown. Glad to add a second
  permission or a separate example if reviewers would rather see one.

## Conflicts

Touches only the field-enumeration line in **Permission sets**.

- #99 (space credential DPoP) edits the space-credential and delegation-token sections
  and the XRPC method table.
- #100 (misc alpha-impl fixes) edits the scope-example bullets, the Matching prose, the
  `simplespace` auth line, and the XRPC method table.

Neither includes this paragraph, in a hunk or as context, so this should apply cleanly in
any merge order.